### PR TITLE
Use builtin fetch if detected

### DIFF
--- a/lib/fetch-mf2.js
+++ b/lib/fetch-mf2.js
@@ -1,5 +1,5 @@
-import { fetch } from "undici";
 import parser from "microformats-parser";
+import { fetch } from "./fetch.js";
 
 /**
  * Fetch Microformats2 from a given URL

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,0 +1,13 @@
+/**
+ * Fetch ponyfill.
+ *
+ * @type {globalThis.fetch}
+ */
+export async function fetch(...args) {
+  if ("fetch" in globalThis) {
+    return globalThis.fetch(...args);
+  }
+
+  const { fetch } = await import("undici");
+  return fetch(...args);
+}


### PR DESCRIPTION
This library becomes unusable on Deno because of the usage of `undici`, which is solely a Node.js targeted library. This can also happen if this module is to be used in browsers. So, to address that, I added a [ponyfill](https://ponyfill.com#ponyfill) which will use native Fetch API if its present or else fall back to `undici`'s Fetch API implementation.

Fetch API's coverage is huge, and using default Fetch would be make sense once v16 reaches EOL (2023-09-11), since v18 supports native Fetch.

Consider this as an effort to make this library more portable, and no hard feelings if this doesn't go through. This patch works for my use case.