### PR TITLE
add metaformats fallback to fetch-references

### DIFF
--- a/lib/fetch-mf2.js
+++ b/lib/fetch-mf2.js
@@ -1,4 +1,4 @@
-import parser from "microformats-parser";
+import { mf2 } from "microformats-parser";
 import { fetch } from "./fetch.js";
 
 /**
@@ -15,9 +15,8 @@ export const fetchMf2 = async (url) => {
     throw new Error(response.statusText);
   }
 
-  const mf2 = parser.mf2(body, {
+  return mf2(body, {
     baseUrl: url,
+    experimental: { metaformats: true },
   });
-
-  return mf2;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
-        "microformats-parser": "^1.4.0",
+        "microformats-parser": "^1.5.1",
         "undici": "^5.9.0"
       },
       "devDependencies": {
@@ -5046,14 +5046,14 @@
       }
     },
     "node_modules/microformats-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/microformats-parser/-/microformats-parser-1.4.1.tgz",
-      "integrity": "sha512-BSg9Y/Aik8hvvme/fkxnXMRvTKuVwOeTapeZdaPQ+92DEubyM31iMtwbgFZ1383om643UvfYY5G23E9s1FY2KQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/microformats-parser/-/microformats-parser-1.5.1.tgz",
+      "integrity": "sha512-Bn4jlYuIIN5NK/5eAJLk7rRYjjbeF29bLpXjQLHl4mmrMs3bynZ683hNC4o/YAbKg8kekrv0973GmCYD2fcb6w==",
       "dependencies": {
         "parse5": "^6.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/micromatch": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "microformats-parser": "^1.5.1",
+    "microformats-parser": "^2.0.0",
     "undici": "^5.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "microformats-parser": "^1.4.0",
+    "microformats-parser": "^1.5.1",
     "undici": "^5.9.0"
   },
   "devDependencies": {

--- a/tests/fetch-references.test.js
+++ b/tests/fetch-references.test.js
@@ -41,3 +41,43 @@ test("Fetches JF2 properties for each referenced URL", async () => {
     expected,
   );
 });
+
+test("Uses metaformats fallback for each referenced URL", async () => {
+  const expected = await fetchReferences({
+    type: "entry",
+    name: "A cool git repo",
+    published: "2019-02-12T10:00:00.000+00:00",
+    category: ["foo", "bar"],
+    url: "https://website.example/bookmarks/repo",
+    "bookmark-of": "https://github.com/getindiekit/mf2tojf2",
+  });
+  console.log(expected);
+  assert.deepEqual(
+    {
+      type: "entry",
+      name: "A cool git repo",
+      published: "2019-02-12T10:00:00.000+00:00",
+      category: ["foo", "bar"],
+      url: "https://website.example/bookmarks/repo",
+      "bookmark-of": "https://github.com/getindiekit/mf2tojf2",
+      references: {
+        "https://github.com/getindiekit/mf2tojf2": {
+          url: "https://github.com/getindiekit/mf2tojf2",
+          type: "entry",
+          name: "getindiekit/mf2tojf2: Convert MF2 to JF2.",
+          summary:
+            "Convert MF2 to JF2. Contribute to getindiekit/mf2tojf2 development by creating an account on GitHub.",
+          featured: [
+            {
+              alt: "Card identifying indieweb/mf2tojf2 repo. Notes 2 contributors, 6 stars, and 2 forks.",
+              value:
+                "https://opengraph.githubassets.com/6d3c627723ff987446e2917808142dfb0e2ccdd9d94db970f9a5aacbb1eb4825/getindiekit/mf2tojf2",
+            },
+          ],
+          publication: "GitHub",
+        },
+      },
+    },
+    expected,
+  );
+});

--- a/tests/fetch-references.test.js
+++ b/tests/fetch-references.test.js
@@ -70,8 +70,7 @@ test("Uses metaformats fallback for each referenced URL", async () => {
           featured: [
             {
               alt: "Card identifying indieweb/mf2tojf2 repo. Notes 2 contributors, 6 stars, and 2 forks.",
-              value:
-                "https://opengraph.githubassets.com/6d3c627723ff987446e2917808142dfb0e2ccdd9d94db970f9a5aacbb1eb4825/getindiekit/mf2tojf2",
+              url: "https://opengraph.githubassets.com/6d3c627723ff987446e2917808142dfb0e2ccdd9d94db970f9a5aacbb1eb4825/getindiekit/mf2tojf2",
             },
           ],
           publication: "GitHub",

--- a/tests/fixtures/repo.html
+++ b/tests/fixtures/repo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>getindiekit/mf2tojf2: Convert MF2 to JF2.</title>
+    <meta name="description" content="Convert MF2 to JF2. Contribute to getindiekit/mf2tojf2 development by creating an account on GitHub.">
+    <meta name="twitter:image:src" content="https://opengraph.githubassets.com/6d3c627723ff987446e2917808142dfb0e2ccdd9d94db970f9a5aacbb1eb4825/getindiekit/mf2tojf2"/>
+    <meta name="twitter:site" content="@github"/>
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:title" content="getindiekit/mf2tojf2: Convert MF2 to JF2."/>
+    <meta name="twitter:description" content="Convert MF2 to JF2. Contribute to getindiekit/mf2tojf2 development by creating an account on GitHub."/>
+    <meta property="og:image" content="https://opengraph.githubassets.com/6d3c627723ff987446e2917808142dfb0e2ccdd9d94db970f9a5aacbb1eb4825/getindiekit/mf2tojf2"/>
+    <meta property="og:image:alt" content="Card identifying indieweb/mf2tojf2 repo. Notes 2 contributors, 6 stars, and 2 forks."/>
+    <meta property="og:image:width" content="1200"/>
+    <meta property="og:image:height" content="600"/>
+    <meta property="og:site_name" content="GitHub"/>
+    <meta property="og:type" content="object"/>
+    <meta property="og:title" content="getindiekit/mf2tojf2: Convert MF2 to JF2."/>
+    <meta property="og:url" content="https://github.com/getindiekit/mf2tojf2"/>
+    <meta property="og:description" content="Convert MF2 to JF2. Contribute to getindiekit/mf2tojf2 development by creating an account on GitHub."/>
+    <link rel="canonical" href="https://github.com/getindiekit/mf2tojf2">
+  </head>
+  <body>
+    <article>
+      <h1>MF2 to JF2</h1>
+      <p>JF2 is a simpler JSON serialization of microformats2 intended to be easier to consume than the standard <a href="https://microformats.org/wiki/microformats2" rel="nofollow">microformats JSON representation</a>.</p>
+    </article>
+  </body>
+</html>

--- a/tests/helpers/mock-agent.js
+++ b/tests/helpers/mock-agent.js
@@ -11,6 +11,12 @@ export const mockAgent = () => {
     .intercept({ path: "/notes/lunch" })
     .reply(200, getFixture("bookmark.html"));
 
+  // Get page without mf2
+  agent
+    .get("https://github.com")
+    .intercept({ path: "/getindiekit/mf2tojf2" })
+    .reply(200, getFixture("repo.html"));
+
   // Get bookmark (Not Found)
   agent
     .get("https://website.example")


### PR DESCRIPTION
Adds metaformats fallback to show data about references from meta tags if they don't have mf2.

Not ready to be merged. Update if/when microformats/microformats-parser#229 is merged and released.

Related to #20