### PR TITLE
Ignore `mp-` prefixed properties when referencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ const mf2 = {
         published: ["2019-02-12T10:00:00.000+00:00"],
         url: ["https://my-website.example/bookmarks/lunch"],
         "bookmark-of": ["https://their-website.example/notes/lunch"],
+        "mp-syndicate-to": "https://example.social/@username",
       },
     },
   ],
@@ -67,6 +68,7 @@ return jf2WithReferences;
 //  published: '2019-02-12T10:00:00.000+00:00',
 //  url: 'https://my-website.example/bookmarks/lunch',
 //  'bookmark-of': 'https://their-website.example/notes/lunch',
+//  'mp-syndicate-to': 'https://example.social/@username',
 //  references: {
 //    'https://their-website.example/notes/lunch': {
 //      type: 'entry',
@@ -82,6 +84,9 @@ return jf2WithReferences;
 //  }
 // }
 ```
+
+> [!NOTE]\
+> Values for `url`, and any property prefixed with `mp-`, are excluded from referencing.
 
 ## Testing
 

--- a/lib/fetch-references.js
+++ b/lib/fetch-references.js
@@ -13,8 +13,13 @@ const referenceableUrls = (jf2) => {
   for (const key in jf2) {
     if (Object.prototype.hasOwnProperty.call(jf2, key)) {
       const value = jf2[key];
+      const referenceableProperty =
+        typeof value === "string" &&
+        URL.canParse(value) &&
+        key !== "url" &&
+        !key.startsWith("mp-");
 
-      if (typeof value === "string" && URL.canParse(value) && key !== "url") {
+      if (referenceableProperty) {
         urls.push(value);
       }
     }

--- a/test/fetch-references.js
+++ b/test/fetch-references.js
@@ -51,6 +51,8 @@ describe("mf2tojf2", () => {
       category: ["foo", "bar"],
       url: "https://website.example/bookmarks/repo",
       "bookmark-of": "https://github.com/getindiekit/mf2tojf2",
+      "mp-destination": "https://website.example",
+      "mp-syndicate-to": "https://example.social/@username",
     });
     assert.deepEqual(
       {
@@ -60,6 +62,8 @@ describe("mf2tojf2", () => {
         category: ["foo", "bar"],
         url: "https://website.example/bookmarks/repo",
         "bookmark-of": "https://github.com/getindiekit/mf2tojf2",
+        "mp-destination": "https://website.example",
+        "mp-syndicate-to": "https://example.social/@username",
         references: {
           "https://github.com/getindiekit/mf2tojf2": {
             url: "https://github.com/getindiekit/mf2tojf2",


### PR DESCRIPTION
Fixes #26.