### PR TITLE
Log referenced URL that doesn’t return a response

### DIFF
--- a/lib/fetch-references.js
+++ b/lib/fetch-references.js
@@ -40,13 +40,17 @@ export const fetchReferences = async (jf2) => {
   const references = jf2.references || {};
 
   for await (const url of urls) {
-    const mf2 = await fetchMf2(url);
-    const properties = mf2tojf2(mf2);
+    try {
+      const mf2 = await fetchMf2(url);
+      const properties = mf2tojf2(mf2);
 
-    references[url] = {
-      url,
-      ...properties,
-    };
+      references[url] = {
+        url,
+        ...properties,
+      };
+    } catch (error) {
+      console.error(`Unable to fetch reference for ${url} (${error.message})`);
+    }
   }
 
   // Only add `references` property if references found

--- a/test/fetch-references.js
+++ b/test/fetch-references.js
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 import { setGlobalDispatcher } from "undici";
 import { fetchReferences } from "../lib/fetch-references.js";
 import { mockClient } from "../helpers/mock-agent.js";
@@ -40,6 +40,34 @@ describe("mf2tojf2", () => {
             category: ["Food", "Lunch", "Sandwiches"],
           },
         },
+      },
+      expected,
+    );
+  });
+
+  it("Logs referenced URL that didn’t return a response", async () => {
+    mock.method(console, "error", () => {});
+
+    const expected = await fetchReferences({
+      type: "entry",
+      name: "What my friend ate for lunch yesterday",
+      published: "2019-02-12T10:00:00.000+00:00",
+      url: "https://website.example/bookmarks/lunch",
+      "bookmark-of": "https://another.example/404.html",
+    });
+
+    assert.equal(
+      console.error.mock.calls[0].arguments[0],
+      `Unable to fetch reference for https://another.example/404.html (Not Found)`,
+    );
+
+    assert.deepEqual(
+      {
+        type: "entry",
+        name: "What my friend ate for lunch yesterday",
+        published: "2019-02-12T10:00:00.000+00:00",
+        url: "https://website.example/bookmarks/lunch",
+        "bookmark-of": "https://another.example/404.html",
       },
       expected,
     );


### PR DESCRIPTION
Fixes #30.

Fetching `mf2` from a URL will still throw an error. However, when fetching `mf2` for any referenced URLs, the error will instead be logged to the console.